### PR TITLE
ВРЕМЕННЫЙ фикс, связанный с Life()-ом у мобов.

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -264,7 +264,7 @@
 	mymob.noise1.name = " "
 	mymob.noise1.screen_loc = "1,1 to 15,15"
 	mymob.noise1.mouse_opacity = 0
-	hud_elements |= mymob.noise1 
+	hud_elements |= mymob.noise1
 
 	mymob.noise2 = new /obj/screen()
 	mymob.noise2.icon = 'icons/mob/noise.dmi'
@@ -311,9 +311,10 @@
 	mymob.radio_use_icon.icon = ui_style
 	mymob.radio_use_icon.color = ui_color
 	mymob.radio_use_icon.alpha = ui_alpha
-
-	mymob.fov = new /obj/screen/fov()
-	hud_elements |= mymob.fov
+	if(ishuman(mymob))
+		var/mob/living/carbon/human/H = mymob
+		H.fov = new /obj/screen/fov()
+		hud_elements |= H.fov
 
 	mymob.client.screen = list()
 

--- a/code/game/antagonist/outsider/actors.dm
+++ b/code/game/antagonist/outsider/actors.dm
@@ -43,7 +43,7 @@ var/datum/antagonist/actor/actor
 	set name = "Join as Actor"
 	set desc = "Join as an Actor to entertain the crew through television!"
 
-	if(!MayRespawn(1))
+	if(!MayRespawn(1) || !holder)
 		return
 
 	var/choice = alert("Are you sure you'd like to join as an actor?", "Confirmation","Yes", "No")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -279,7 +279,7 @@ its easier to just keep the beam vertical.
 /atom/proc/clean_blood()
 	if(!simulated)
 		return
-	fluorescent = 0F
+	fluorescent = 0
 	src.germ_level = 0
 	if(istype(blood_DNA, /list))
 		blood_DNA = null
@@ -386,13 +386,13 @@ its easier to just keep the beam vertical.
 /atom/proc/kick_act(mob/living/carbon/human/user)
 	if(!Adjacent(user))//They're not adjcent to us so we can't kick them.
 		return
-		
+
 	if(user.handcuffed && rand(1, 100) <= 35)//User can fail to kick smbd if cuffed
 		user.visible_message("<span class='danger'>[user.name] loses \his balance while trying to kick \the [src].</span>", \
 					"<span class='warning'> You lost your balance.</span>")
 		user.Weaken(5)
 		return
-		
+
 	if(user.middle_click_intent == "kick")//We're in kick mode, we can kick.
 		for(var/limbcheck in list(BP_L_LEG,BP_R_LEG))//But we need to see if we have legs.
 			var/obj/item/organ/affecting = user.get_organ(limbcheck)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1115,8 +1115,9 @@
 	if(!src.occupant) return
 	var/atom/movable/mob_container
 	if(ishuman(occupant))
+		var/mob/living/carbon/human/H = occupant
 		mob_container = src.occupant
-		occupant.show_cone()
+		H.show_cone()
 	else if(istype(occupant, /mob/living/carbon/brain))
 		var/mob/living/carbon/brain/brain = occupant
 		mob_container = brain.container

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -630,7 +630,9 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 				user.client.pixel_y = 0
 
 		user.visible_message("\The [user] peers through the [zoomdevicename ? "[zoomdevicename] of [src]" : "[src]"].")
-		user.hide_cone()
+		if(ishuman(user))
+			var/mob/living/carbon/human/HM = user
+			HM.hide_cone()
 
 	else
 		user.client.view = world.view
@@ -643,8 +645,9 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 		if(!cannotzoom)
 			user.visible_message("[zoomdevicename ? "\The [user] looks up from [src]" : "\The [user] lowers [src]"].")
-			user.show_cone()
-
+			if(ishuman(user))
+				var/mob/living/carbon/human/HM = user
+				HM.show_cone()
 	return
 
 /obj/item/proc/pwr_drain()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -112,3 +112,5 @@
 	var/innate_heal = 1
 
 	var/footstep = 0
+
+	var/obj/screen/fov = null//The screen object because I can't figure out how the hell TG does their screen objects so I'm just using legacy code.

--- a/code/modules/mob/vision_cone.dm
+++ b/code/modules/mob/vision_cone.dm
@@ -12,9 +12,6 @@
 //Defines.
 #define OPPOSITE_DIR(D) turn(D, 180)
 
-/mob
-	var/obj/screen/fov = null//The screen object because I can't figure out how the hell TG does their screen objects so I'm just using legacy code.
-
 client/
 	var/list/hidden_atoms = list()
 	var/list/hidden_mobs = list()
@@ -42,11 +39,11 @@ mob/dead/InCone(mob/center = usr, dir = NORTH)
 mob/living/InCone(mob/center = usr, dir = NORTH)
 	. = ..()
 	for(var/obj/item/weapon/grab/G in center)//TG doesn't have the grab item. But if you're porting it and you do then uncomment this.
-		if(src == G.affecting) 
+		if(src == G.affecting)
 			return 0
-		else 
+		else
 			return .
-	
+
 
 proc/cone(atom/center = usr, dir = NORTH, list/list = oview(center))
     for(var/atom/O in list) if(!O.InCone(center, dir)) list -= O
@@ -55,13 +52,13 @@ proc/cone(atom/center = usr, dir = NORTH, list/list = oview(center))
 mob/proc/update_vision_cone()
 	return
 
-mob/living/update_vision_cone()
+mob/living/carbon/human/update_vision_cone()
 	var/delay = 10
 	if(src.client)
 		var/image/I = null
 		for(I in src.client.hidden_atoms)
 			I.override = 0
-			spawn(delay) 
+			spawn(delay)
 				qdel(I)
 			delay += 10
 		rest_cone_act()
@@ -90,17 +87,17 @@ mob/living/update_vision_cone()
 	else
 		return
 
-mob/proc/rest_cone_act()//For showing and hiding the cone when you rest or lie down.
+mob/living/carbon/human/proc/rest_cone_act()//For showing and hiding the cone when you rest or lie down.
 	if(resting || lying)
 		hide_cone()
 	else
 		show_cone()
 
 //Making these generic procs so you can call them anywhere.
-mob/proc/show_cone()
+mob/living/carbon/human/proc/show_cone()
 	if(src.fov)
 		src.fov.alpha = 255
 
-mob/proc/hide_cone()
+mob/living/carbon/human/proc/hide_cone()
 	if(src.fov)
 		src.fov.alpha = 0


### PR DESCRIPTION
Проблема здоровья мышек (да и вообще всех мобов) заключалась в том, что Life() у mob/living банально не работал. Вообще, это фикс не только мышек, а достаточно многих мобов, у которого из-за этого могли быть проблемы.
Это временное решение. По уму надо немного изменить код ФОВ-а и запилить его для /mob/living/carbon, но мне лень лезть в интерфейсы, пускай пока так.

UPD: Ещё запретил игрокам обычным заходить за акторов.

closed #120 
closed #119 