### PR TITLE
Переработан дамаг от кидания людей

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -254,6 +254,3 @@ var/const/enterloopsanity = 100
 	if(src.density)
 		spawn(2)
 			step(AM, turn(AM.last_move, 180))
-		if(isliving(AM))
-			var/mob/living/M = AM
-			M.turf_collision(src, speed)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1564,24 +1564,25 @@
 			play_xylophone()
 
 /mob/living/carbon/human/throw_impact(atom/hit_atom)
-	if(iswall(hit_atom))
-		var/damage = rand(0, 10)
-		var/smashsound = pick('sound/effects/gore/smash1.ogg', 'sound/effects/gore/smash2.ogg', 'sound/effects/gore/smash3.ogg', 'sound/effects/gore/trauma1.ogg')
-		playsound(loc, smashsound, 50, 1, -1)
+	var/damage = rand(0, 25)
+	var/smashsound = pick('sound/effects/gore/smash1.ogg', 'sound/effects/gore/smash2.ogg', 'sound/effects/gore/smash3.ogg', 'sound/effects/gore/trauma1.ogg')
+	playsound(loc, smashsound, 50, 1, -1)
 
-		var/blocked = run_armor_check(BP_HEAD,"melee")
-		apply_damage(damage, BRUTE, BP_HEAD, blocked)
+	var/blocked = run_armor_check(BP_HEAD,"melee")
+	blocked += run_armor_check(BP_CHEST,"melee")
+	blocked += run_armor_check(BP_GROIN,"melee")
+	blocked += run_armor_check(BP_L_HAND,"melee")
+	blocked += run_armor_check(BP_R_HAND,"melee")
+	blocked += run_armor_check(BP_L_ARM,"melee")
+	blocked += run_armor_check(BP_R_ARM,"melee")
+	blocked += run_armor_check(BP_L_FOOT,"melee")
+	blocked += run_armor_check(BP_R_FOOT,"melee")
+	blocked += run_armor_check(BP_L_LEG,"melee")
+	blocked += run_armor_check(BP_R_LEG,"melee")
+	
+	src.take_organ_damage(damage * (1 - blocked/1100))
 
-		blocked = run_armor_check(BP_CHEST,"melee")
-		apply_damage(damage, BRUTE, BP_CHEST, blocked)
-
-		blocked = run_armor_check(BP_GROIN,"melee")
-		apply_damage(damage, BRUTE, BP_GROIN, blocked)
-
-		updatehealth()
-		if(damage)
-			hit_atom.add_blood(src)
-		..()
-
-	else
-		..()
+	updatehealth()
+	if(damage)
+		hit_atom.add_blood(src)
+	..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1564,7 +1564,7 @@
 			play_xylophone()
 
 /mob/living/carbon/human/throw_impact(atom/hit_atom)
-	var/damage = rand(0, 25)
+	var/damage = rand(1, 25)
 	var/smashsound = pick('sound/effects/gore/smash1.ogg', 'sound/effects/gore/smash2.ogg', 'sound/effects/gore/smash3.ogg', 'sound/effects/gore/trauma1.ogg')
 	playsound(loc, smashsound, 50, 1, -1)
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -213,10 +213,6 @@
 	src.embedded += O
 	src.verbs += /mob/proc/yank_out_object
 
-//This is called when the mob is thrown into a dense turf
-/mob/living/proc/turf_collision(var/turf/T, var/speed)
-	src.take_organ_damage(speed*5)
-
 /mob/living/proc/near_wall(var/direction,var/distance=1)
 	var/turf/T = get_step(get_turf(src),direction)
 	var/turf/last_turf = src.loc


### PR DESCRIPTION
- Отныне стенки не отрывают конечности (хотя я не уверен, если что дамаг всегда можно понизить)
- Теперь недруга можно впилить в любой плотный объект (obj или turf, до мобов дело пока не дошло)
- Дамаг от удара отныне расчитывается исходя из брони, поэтому ушатать голого ассистента об стену проще и быстрее чем СБшника в riot suit'e.

