### PR TITLE
Фикс времени смерти

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -74,7 +74,7 @@ REAGENT SCANNER
 	user.show_message("<span class='notice'>    Damage Specifics: <font color='blue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font></span>")
 	user.show_message("<span class='notice'>Body Temperature: [M.bodytemperature-T0C]&deg;C ([M.bodytemperature*1.8-459.67]&deg;F)</span>", 1)
 	if(M.stat == DEAD || (M.status_flags & FAKEDEATH))
-		user.show_message("<span class='notice'>Time of Death: [time2text(worldtime2stationtime(M.timeofdeath), "hh:mm")]</span>")
+		user.show_message("<span class='notice'>Time of Death: [worldtime2stationtime(M.timeofdeath)]</span>")
 	if(istype(M, /mob/living/carbon/human) && mode == 1)
 		var/mob/living/carbon/human/H = M
 		var/list/damaged = H.get_damaged_organs(1,1)


### PR DESCRIPTION
Теперь сканер отображает (почти) коректное время смерти.
Погрешность в минуту величиной, не знаю с чем это вызвано.
fixes #99