### PR TITLE
Fixed an infinite-metal exploit

### DIFF
--- a/code/modules/integrated_electronics/machine_printer.dm
+++ b/code/modules/integrated_electronics/machine_printer.dm
@@ -44,8 +44,9 @@ var/list/integrated_circuit_blacklist = list(/obj/item/integrated_circuit, /obj/
 					updateUsrDialog()
 					return 1
 	if(default_deconstruction_screwdriver(user, O))
-		new /obj/item/stack/material/steel(get_turf(loc), metal)
-		metal = 0
+		if(metal)
+ 			new /obj/item/stack/material/steel(get_turf(loc), metal)
+ 			metal = 0
 		return
 	if(default_deconstruction_crowbar(user, O))
 		return

--- a/code/modules/integrated_electronics/machine_printer.dm
+++ b/code/modules/integrated_electronics/machine_printer.dm
@@ -45,8 +45,8 @@ var/list/integrated_circuit_blacklist = list(/obj/item/integrated_circuit, /obj/
 					return 1
 	if(default_deconstruction_screwdriver(user, O))
 		if(metal)
- 			new /obj/item/stack/material/steel(get_turf(loc), metal)
- 			metal = 0
+			new /obj/item/stack/material/steel(get_turf(loc), metal)
+			metal = 0
 		return
 	if(default_deconstruction_crowbar(user, O))
 		return


### PR DESCRIPTION
### Изменения:
 - Порт [исправления](https://github.com/Baystation12/Baystation12/pull/18111) из репозитория Baystation12 
 - Исправляет дюп листов металла при откручивании крышки интегрированного принтера плат